### PR TITLE
Select USB configuration if it is null

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+webcfw.sdsetup.com

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-webcfw.sdsetup.com

--- a/main.js
+++ b/main.js
@@ -100,6 +100,10 @@ async function launchPayload(payload) {
   await device.open();
   logOutput(`Connected to ${device.manufacturerName} ${device.productName}`);
 
+  if (device.configuration === null) {
+    await device.selectConfiguration(1);
+  }
+
   await device.claimInterface(0);
 
   const deviceID = await device.transferIn(1, 16);


### PR DESCRIPTION
The `claimInterface(0)` call fails (at least on OSX), because there is no selected configuration.
Fixing it according to the [docs](https://developer.mozilla.org/en-US/docs/Web/API/USBDevice/claimInterface#Example).

You can test it here: https://peterholczbauer-prezi.github.io/web-cfw-loader/